### PR TITLE
Adding a !feedback command

### DIFF
--- a/cogs/feedback.py
+++ b/cogs/feedback.py
@@ -1,0 +1,64 @@
+import json
+
+import discord
+from discord.ext import commands
+
+import libs.config as config
+from libs.embedmaker import officialEmbed
+
+
+############################
+# Strings & Embed Features #
+############################
+
+# Feedback variable to retrieve strings from config.json
+s_feedback = config.get_string("feedback")
+
+
+# Use THM logo from config.json as embed picture
+c_feedback_picture = config.get_config("info")["logo"]
+
+# Use already defined site color from config.json as embed color
+c_feedback_color = config.get_config("colors")["site"]
+
+
+# Embed Title
+s_feedback_title = s_feedback["title"]
+
+# Embed URL
+s_feedback_url = s_feedback["url"]
+
+# Embed Field
+s_feedback_message = s_feedback["message"]
+
+
+#############
+# Functions #
+#############
+
+# Setup the arguments for the embed to use the features gathered from config.json + create field.
+
+def getEmbedFeedback(n, t, c):
+
+    response = officialEmbed(n, color=c)
+    response.set_thumbnail(url=t)
+    response.add_field(name="Sharing your experience:", value=s_feedback_message + " " + s_feedback_url, inline=False)
+    return response
+
+############
+# COG Body #
+############
+
+class Feedback(commands.Cog, name="Provide Feedback"):
+    def __init__(self, bot):
+        self.bot = bot
+
+# Use help_desc from config.json for commmand description in !help
+    @commands.command(name="feedback", description=s_feedback["help_desc"])
+    async def feedback(self, ctx):
+        response = getEmbedFeedback(s_feedback_title, c_feedback_picture, c_feedback_color)
+        await ctx.send(embed=response)
+
+
+def setup(bot):
+    bot.add_cog(Feedback(bot))

--- a/config/config.json
+++ b/config/config.json
@@ -24,7 +24,8 @@
         "cogs.social",
         "cogs.devrole",
         "cogs.fun",
-        "cogs.help"
+        "cogs.help",
+        "cogs.feedback"
     ],
     "disabled_cogs":[
     ],

--- a/config/strings.json
+++ b/config/strings.json
@@ -31,6 +31,12 @@
             "Start the VPN with sudo openvpn <path-to-config>"
         ]
     },
+    "feedback":{
+        "help_desc":"Let us know what you think of TryHackMe!",
+        "title":"Providing feedback to TryHackMe",
+        "url":"https://tryhackme.com/feedback",
+        "message":"We'd love to hear your thoughts and experiences on the TryHackMe site and its contents. Bug reports and ideas are also welcome through this form:"
+    },
     "giveaway":{
         "help_desc":"Create a giveaway.",
         "help_desc_canceled":"Cancel the current giveaway.",


### PR DESCRIPTION
Directing users to the THM/feedback url where they can share their thoughts about the site - as per Darks request. The feedback command has been thrown into its own cog for consistency + the possibility of further extending the use of feedback at a later date.