### PR TITLE
~Fixed room cog.

### DIFF
--- a/cogs/room.py
+++ b/cogs/room.py
@@ -56,9 +56,9 @@ async def announce_room(channel, json_data, code=None):
     img = json_data["image"]
     title = json_data["title"]
     if code == None:
-        url = c_url_room["room"] + str(json_data["code"])
+        url = c_url_room + str(json_data["code"])
     else:
-        url = c_url_room["room"] + code
+        url = c_url_room + code
     description = json_data["description"]
 
     embed = officialEmbed(title, description)


### PR DESCRIPTION
A mistake has been made when retrieving the URL from the config.
That led to the room cog crashing on any room announcement.