### PR TITLE
Adding Discord social & updating README.md

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "python.pythonPath": "C:\\Users\\CMNatic\\AppData\\Local\\Programs\\Python\\Python36\\python.exe",
-    "python.linting.pylintEnabled": true,
-    "python.linting.enabled": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "python.pythonPath": "C:\\Users\\zilot\\AppData\\Local\\Microsoft\\WindowsApps\\python.exe",
+    "python.pythonPath": "C:\\Users\\CMNatic\\AppData\\Local\\Programs\\Python\\Python36\\python.exe",
     "python.linting.pylintEnabled": true,
     "python.linting.enabled": true
 }

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ TryHackMe Python Discord Bot
   - Leaderboard generation, tweet command
 - Horshark
   - Room cog, role sync, stats, rank, rules, help/staff, vote, giveaway, faq, jira, overall rewrite and improvement, minor features and fixes
+- CMNatic
+  - Housekeeping, feedback.
 
 
 ***Commands:***
@@ -65,6 +67,7 @@ github | Get the bot's Github link.
 twitter | Get the Twitter link.
 reddit | Get the Reddit link.
 website | Get the Website link.
+discord | Get the Discord invite.
 social | Get links to all our socials.
 tweet | Get THM's last tweet.
 
@@ -82,3 +85,6 @@ xkcd | Send a random XKCD comic.
 > Help
 staff | Displays all staff commands.
 help | Displays all commands.
+
+> Provide Feedback
+feedback | Let us know what you think of TryHackMe!

--- a/cogs/social.py
+++ b/cogs/social.py
@@ -28,30 +28,35 @@ twitter = social["twitter"]
 reddit = social["reddit"]
 website = social["website"]
 tweet = social["tweet"]
+discord = social["discord"]
 
 # URLs.
 gitURL = github["url"]
 twitterURL = twitter["url"]
 redditURL = reddit["url"]
 websiteURL = website["url"]
+discordURL = discord["url"]
 
 # Titles.
 gitTitle = github["title"]
 twitterTitle = twitter["title"]
 redditTitle = reddit["title"]
 websiteTitle = website["title"]
+discordTitle = discord["title"]
 
 # Pictures.
 gitPic = github["pic"]
 twitterPic = twitter["pic"]
 redditPic = reddit["pic"]
 websitePic = website["pic"]
+discordPic = discord["pic"]
 
 # Colors
 twitterColor = 0x08a0e9
 redditColor = 0xff5700
 websiteColor = 0x000000
 gitColor = 0x0463C4
+discordColor = 0x7289da
 
 
 #############
@@ -97,6 +102,12 @@ class Social(commands.Cog):
         response = getEmbedSocial(
             websiteTitle, websiteURL, websitePic, websiteColor)
         await ctx.send(embed=response)
+    
+    @commands.command(description=discord["help_desc"])
+    async def discord(self, ctx):
+        response = getEmbedSocial(
+            discordTitle, discordURL, discordPic, discordColor)
+        await ctx.send(embed=response)
 
     @commands.command(description=social["help_desc"])
     async def social(self, ctx):
@@ -111,6 +122,10 @@ class Social(commands.Cog):
         response = getEmbedSocial(
             websiteTitle, websiteURL, websitePic, websiteColor)
         await ctx.send(embed=response)
+
+        response = getEmbedSocial(
+            discordTitle, discordURL, discordPic, discordColor)
+        await ctx.send(embed=response)    
 
     @commands.command(name="tweet", description=tweet["help_desc"])
     async def last_tweet(self, ctx):

--- a/config/strings.json
+++ b/config/strings.json
@@ -160,6 +160,12 @@
         },
         "tweet":{
             "help_desc":"Get THM's last tweet."
+        },
+        "discord":{
+            "help_desc":"Get the Discord invite.",
+            "url":"https://discord.gg/F7ERYzz",
+            "title":"TryHackMe's Discord:",
+            "pic":"https://tryhackme.com/img/THMlogo.png"
         }
     },
     "stats":{


### PR DESCRIPTION
I have added the THM Discord to the socials cog to close #116 as per community request.

However, rather then using the vanity url, I have used the specific invite link from the THM website as the vanity url requires a certain number of nitro boosters to be valid.

TL:DR:
- Added "!discord" to socials cog - using invite code > vanity url which could 404
- Updated Readme.md adding myself to contributors, listing discord and feedback command to list.