### PR TITLE
Resolving #96 - Join room URL for the new room announcements & New API endpoint

### DIFF
--- a/cogs/room.py
+++ b/cogs/room.py
@@ -22,7 +22,7 @@ c_room_default_data = config.get_config("data_files")["room_default"]
 c_sleep_time = config.get_config("sleep_time")["room_listener"]
 c_api_url = config.get_config("url")["api"]
 c_url_room = config.get_config("url")["room"]
-c_join_room = config.get_config("url")["join_room"]
+c_join_room = config.get_config("url")["room_join"]
 
 #####################
 # Strings variables #

--- a/cogs/room.py
+++ b/cogs/room.py
@@ -22,7 +22,7 @@ c_room_default_data = config.get_config("data_files")["room_default"]
 c_sleep_time = config.get_config("sleep_time")["room_listener"]
 c_api_url = config.get_config("url")["api"]
 c_url_room = config.get_config("url")["room"]
-c_join_room = config.get_config("url")["join"]
+c_join_room = config.get_config("url")["join_room"]
 
 #####################
 # Strings variables #

--- a/cogs/room.py
+++ b/cogs/room.py
@@ -22,7 +22,7 @@ c_room_default_data = config.get_config("data_files")["room_default"]
 c_sleep_time = config.get_config("sleep_time")["room_listener"]
 c_api_url = config.get_config("url")["api"]
 c_url_room = config.get_config("url")["room"]
-
+c_join_room = config.get_config("url")["join"]
 
 #####################
 # Strings variables #
@@ -30,6 +30,7 @@ c_url_room = config.get_config("url")["room"]
 
 s_no_perm = config.get_string("no_perm")
 s_room = config.get_string("room")
+
 
 
 ###################
@@ -56,9 +57,9 @@ async def announce_room(channel, json_data, code=None):
     img = json_data["image"]
     title = json_data["title"]
     if code == None:
-        url = c_url_room + str(json_data["code"])
+        url = c_join_room + str(json_data["code"])
     else:
-        url = c_url_room + code
+        url = c_join_room + code
     description = json_data["description"]
 
     embed = officialEmbed(title, description)
@@ -83,7 +84,7 @@ class Room(commands.Cog):
     @commands.command(description=s_room["writeup_help_desc"], usage="{room_code}")
     async def writeup(self, ctx, room_code):
         # Request to the API.
-        data = await api_fetch(c_api_url["room"], "/", room_code)
+        data = await api_fetch(c_api_url["room"].format(room_code))
 
         # If the specified code is wrong.
         if data["success"] == False:
@@ -103,7 +104,7 @@ class Room(commands.Cog):
         # Set up embed.
         img = data["image"]
         title = data["title"]
-        link = c_url_room + room_code
+        link = c_join_room + room_code
 
         embed = officialEmbed(title, link)
         embed.set_image(url=img)
@@ -135,7 +136,7 @@ class Room(commands.Cog):
         await announce_room(channel, data[0])
 
     @commands.command(name="newroom", description=s_room["newroom_help_desc"] + " (Admin)", usage="{room_code}", hidden=True)
-    async def new_room(self, ctx, room):
+    async def new_room(self, ctx, room=""):
         if not has_role(ctx.author, adminID):
             botMsg = await ctx.send(s_no_perm)
 
@@ -144,16 +145,20 @@ class Room(commands.Cog):
             await botMsg.delete()
             await ctx.message.delete()
             return
+        
+        if room == "":
+            await ctx.send(s_room["no_code"])
+        
+        else:
+            data = await api_fetch(c_api_url["room"].format(room))
 
-        data = await api_fetch(c_api_url["room"], "/", room)
+            if data["success"] == False:
+                await ctx.send(s_room["code_not_found"].format(room))
+                return
 
-        if data["success"] == False:
-            await ctx.send(s_room["code_not_found"].format(room))
-            return
+            channel = self.bot.get_channel(channelID)
 
-        channel = self.bot.get_channel(channelID)
-
-        await announce_room(channel, data, room)
+            await announce_room(channel, data, room)
 
     async def new_room_listener(self):
         """Function responsible to loop and listen for a new room release."""

--- a/cogs/room.py
+++ b/cogs/room.py
@@ -104,7 +104,7 @@ class Room(commands.Cog):
         # Set up embed.
         img = data["image"]
         title = data["title"]
-        link = c_join_room + room_code
+        link = c_url_room + room_code
 
         embed = officialEmbed(title, link)
         embed.set_image(url=img)

--- a/config/config.json
+++ b/config/config.json
@@ -76,10 +76,11 @@
     "url":{
         "invite":"https://discord.gg/GzVZtGX",
         "room":"http://tryhackme.com/room/",
+        "join":"https://tryhackme.com/jr/",
         "user_profile":"https://tryhackme.com/p/{}",
         "api":{
-            "room":"https://tryhackme.com/api/room/",
-            "newrooms":"http://tryhackme.com/api/newrooms/",
+            "room":"https://tryhackme.com/api/room/{}",
+            "newrooms":"http://tryhackme.com/api/new-rooms/",
             "token":"https://tryhackme.com/tokens/discord/",
             "leaderboard":"https://tryhackme.com/api/leaderboards",
             "user":"https://tryhackme.com/api/user/{}",

--- a/config/config.json
+++ b/config/config.json
@@ -76,7 +76,7 @@
     "url":{
         "invite":"https://discord.gg/GzVZtGX",
         "room":"http://tryhackme.com/room/",
-        "join":"https://tryhackme.com/jr/",
+        "join_room":"https://tryhackme.com/jr/",
         "user_profile":"https://tryhackme.com/p/{}",
         "api":{
             "room":"https://tryhackme.com/api/room/{}",

--- a/config/config.json
+++ b/config/config.json
@@ -76,7 +76,7 @@
     "url":{
         "invite":"https://discord.gg/GzVZtGX",
         "room":"http://tryhackme.com/room/",
-        "join_room":"https://tryhackme.com/jr/",
+        "room_join":"https://tryhackme.com/jr/",
         "user_profile":"https://tryhackme.com/p/{}",
         "api":{
             "room":"https://tryhackme.com/api/room/{}",

--- a/config/strings.json
+++ b/config/strings.json
@@ -113,7 +113,8 @@
         "newroom_help_desc":"Manually announce a new room.",
         "writeup_help_desc":"Get the writeups for a room.",
         "writeup_not_found":"Sorry, there is no writeup for this room.",
-        "code_not_found":"Sorry, but the room code ``{}`` could not be found."
+        "code_not_found":"Sorry, but the room code ``{}`` could not be found.",
+        "no_code":"Please provide a room code to be announced"
     },
     "rules":[
 		"No unsolicited direct messages (DMs) to other members of the discord. This includes staff. Verify that the member you are messaging is ok with you sending them DMs. The only exception to this rule is if a situation warrants the involvement of a moderator in order to handle something such as harassment or a situation where another member of the discord has made you feel uncomfortable.",


### PR DESCRIPTION
Announcements are now listed via a "join" url in `config.json` and their room code, where before they were listed by the "room" url and then their room code.

This is to close #96 thanks!

## For example:
Previously -  https://tryhackme.com/room/roomcode
Now - https://tryhackme.com/jr/roomcode

## Other changes:
- The endpoint for "newrooms" changed from "/api/newrooms" to "/api/new-rooms" admins can now manually list rooms
- Error catching if an admin doesn't provide a room code to `!newroom`