### PR TITLE
Implemented !docs to embed specific topics based on args, and updated…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ TryHackMe Python Discord Bot
 - Horshark
   - Room cog, role sync, stats, rank, rules, help/staff, vote, giveaway, faq, jira, overall rewrite and improvement, database; utils; commands libs, minor features and fixes
 - CMNatic
-  - Housekeeping / general maintenance, feedback, vpnscript
+  - Housekeeping / general maintenance, integrating thm help site, feedback, vpnscript
 - 5nake.exe
   - Exploitdb search
 

--- a/cogs/docs.py
+++ b/cogs/docs.py
@@ -1,0 +1,154 @@
+import discord
+from discord.ext import commands
+
+import libs.config as config
+from libs.embedmaker import officialEmbed
+
+# QoL / TODO
+# Look into integrating HelpJuice API so all topics can be retrieved via requests and parameters
+
+
+###################
+# Other variables #
+###################
+
+# Embeds data.
+s_docs = config.get_string("docs")
+
+# Retrieve list of all topics and commands & unexpected error message
+s_topics = s_docs["topics"]
+s_commands = s_docs["commands"]
+s_error = s_docs["error"]
+
+
+
+# Store all objects in strings "topics"
+s_topics = s_docs["topics"] 
+
+# THM Logo & Color for embed
+c_docs_picture = config.get_config("info")["logo"]
+c_docs_color = config.get_config("colors")["site"]
+
+
+# Begin grabbing string entries for individual topics
+
+# URL topic
+s_url = s_docs["url"]
+s_url_url = s_url["url"]
+s_url_title = s_url["title"]
+s_url_help = s_url["help_desc"]
+
+# Verify topic
+s_verify = s_docs["verify"]
+s_verify_url = s_verify["url"]
+s_verify_title = s_verify["title"]
+s_verify_help = s_verify["help_desc"]
+
+# Student topic
+s_student = s_docs["student"]
+s_student_url = s_student["url"]
+s_student_title = s_student["title"]
+s_student_help = s_student["help_desc"]
+
+# Levels topic
+s_levels = s_docs["levels"]
+s_levels_url = s_levels["url"]
+s_levels_title = s_levels["title"]
+s_levels_help = s_levels["help_desc"]
+
+# Room Notes topic
+s_room_notes = s_docs["room_notes"]
+s_room_notes_url = s_room_notes["url"]
+s_room_notes_title = s_room_notes["title"]
+s_room_notes_help = s_room_notes["help_desc"]
+
+# Room Review topic
+s_room_review = s_docs["room_review"]
+s_room_review_url = s_room_review["url"]
+s_room_review_title = s_room_review["title"]
+s_room_review_help = s_room_review["help_desc"]
+
+# Api topic
+s_api = s_docs["api"]
+s_api_url = s_api["url"]
+s_api_title = s_api["title"]
+s_api_help_desc = s_api["help_desc"]
+
+# Koth topic
+s_koth = s_docs["koth"]
+s_koth_url = s_koth["url"]
+s_koth_title = s_koth["title"]
+s_koth_help_desc = s_koth["help_desc"]
+
+
+#############
+# Functions #
+#############
+
+# Make embeds.
+def getEmbedDocs(n, v, t, c):
+    """Setup embed for doc topics"""
+
+    response = officialEmbed(n, v, color=c)
+    response.set_thumbnail(url=t)
+    return response
+
+class Docs(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(name="docs", description=s_docs["help_desc"], usage="{topic}", pass_context=True)
+    async def docs(self, ctx, *, topic=""):
+        if not topic:
+            response = officialEmbed(title="Here are all of the possible topics!")
+            response.set_thumbnail(url=(c_docs_picture))
+
+            for i in range(1, len(s_commands)):
+                response.add_field(name=s_commands[i], value=s_topics[i])
+
+            await ctx.send(embed=response)
+            return
+        
+        elif topic == "url":
+            response = getEmbedDocs(s_url_title, s_url_url, c_docs_picture, c_docs_color)
+            await ctx.send(embed=response)
+        
+        elif topic == "verify":
+            response = getEmbedDocs(s_verify_title, s_verify_url, c_docs_picture, c_docs_color)
+            await ctx.send(embed=response)
+        
+        elif topic == "student":
+            response = getEmbedDocs(s_student_title, s_student_url, c_docs_picture, c_docs_color)
+            await ctx.send(embed=response)
+
+
+        elif topic == "levels":
+            response = getEmbedDocs(s_levels_title, s_levels_url, c_docs_picture, c_docs_color)
+            await ctx.send(embed=response)
+
+        elif topic == "room-notes":
+            response = getEmbedDocs(s_room_notes_title, s_levels_url, c_docs_picture, c_docs_color)
+            await ctx.send(embed=response)
+
+        elif topic == "room-review":
+            response = getEmbedDocs(s_room_review_title, s_levels_url, c_docs_picture, c_docs_color)
+            await ctx.send(embed=response)
+
+        elif topic == "api":
+            response = getEmbedDocs(s_api_title, s_api_url, c_docs_picture, c_docs_color)
+            await ctx.send(embed=response)
+        
+        elif topic == "koth":
+            response = getEmbedDocs(s_koth_title, s_koth_url, c_docs_picture, c_docs_color)
+            await ctx.send(embed=response)
+
+        # If anything other then the arguments are provided, say that the topic provided does not exist
+        else:
+            response = officialEmbed(title="That topic does not exist!")
+            response.set_thumbnail(url=(c_docs_picture))
+
+            await ctx.send(embed=response)
+            return
+
+def setup(bot):
+    bot.add_cog(Docs(bot))

--- a/config/config.json
+++ b/config/config.json
@@ -25,7 +25,8 @@
     "cogs.fun",
     "cogs.help",
     "cogs.feedback",
-    "cogs.exploit-db"
+    "cogs.exploit-db",
+    "cogs.docs"
   ],
   "disabled_cogs": [],
   "info": {

--- a/config/strings.json
+++ b/config/strings.json
@@ -139,12 +139,78 @@
 		"Do not post viruses or malicious files without explicit permission from the administrative staff. We understand that this is a discord for learning, however, there are plenty of places online to get malware for forensic examination and reverse engineering.",
         "No distribution of illegally obtained materials within the discord. Do not pirate books in <#679099130320125952>",
         "If you use a Nitro boost on the server you get a pick a new server emote. If you do this twice you get two emotes. Emotes must be server appropriate.",
-        "When asking for help/tech support please perform research to your fullest ability. Mods and Community Mentors have the right to refuse helping those who have not done troubleshooting/research on their own first. Clearly phrase your questions as we (fortunately for all parties involved) cannot read your mind. Please include the room, task, and question number in your question if possible. \n\nWe politely ask you to respect the competitive nature of newly released challenges and to allow at least a week before asking for hints and/or help. This rule should be used as a guideline when providing help to others.",
+        "When asking for help/tech support please perform research to your fullest ability. Mods and Community Mentors have the right to refuse helping those who have not done troubleshooting/research on their own first. Clearly phrase your questions as we (fortunately for all parties involved) cannot read your mind. Please include the room, task, and question number in your question if possible. \n\nAlthough we are a a learning platform, we politely ask that you respect the competitive nature of newly released challenges. As such, no hints for new challenge boxes should be given immediately after a release, unless specifically allowed by the content creator.",
         "You're welcome to post livestreams, writeups, and videos of THM content, just please post them in <#644263827742916628>.",
         "Please leave any disciplinary measures to the discord staff (Trial Mods, Mods, and Admins). This is also known as no 'mini-modding'. If something is happening, please just let the staff know and we can take care of it <3",
         "No spamming, please. This includes excess repeating of the same messages (typically from five upwards, however, staff reserve the right to further judgement in these cases).",
         " Do not intentionally mislead others with malicious intent, especially should this misleading end up in destruction of property or otherwise damaging. Things like rickrolling are still allowed, just don't lead someone to damaging their computer/system."
     ],
+    "docs":{
+        "help_desc":"List our documented topics.",
+        "error":"An unexpected error has occurred. Please contact THM's BOT maintainers.",
+        "topics":[
+            "",
+            "Visit the help site",
+            "Learn how to sync your THM profile to Discord",
+            "Learn about our student discount programme",
+            "View all the TryHackMe levels & point requirements",
+            "Get started with making TryHackMe room",
+            "Learn about the TryHackMe room review process",
+            "Read about the TryHackMe API",
+            "How to play TryHackMe's King of the Hill (KoTH)"
+        ],
+        "commands":[
+            "",
+            "!docs url",
+            "!docs verify",
+            "!docs student",
+            "!docs levels",
+            "!docs room-notes",
+            "!docs room-review",
+            "!docs api",
+            "!docs koth"
+        ],
+        "url":{
+            "help_desc":"Visit the help site",
+            "url":"https://help.tryhackme.com/",
+            "title":"Help Website"
+        },
+        "verify":{
+            "help_desc":"Learn how to verify your THM profile",
+            "url":"https://help.tryhackme.com/community/discord",
+            "title":"Verify your TryHackMe Profile!"
+        },
+        "student":{
+            "help_desc":"Learn about our student discount programme",
+            "url":"https://help.tryhackme.com/billing/student-discount",
+            "title":"Redeem your student discount!"
+        },
+        "levels":{
+            "help_desc":"View all the TryHackMe levels & their point requirements",
+            "url":"https://help.tryhackme.com/using-tryhackme/what-are-levels-on-tryhackme",
+            "title":"View all the TryHackMe levels & their point requirements"
+        },
+        "room_notes":{
+            "help_desc":"Get started with making TryHackMe rooms",
+            "url":"https://help.tryhackme.com/room-creation/room-creation-overview",
+            "title":"Get started with making TryHackMe rooms!"
+        },
+        "room_review":{
+            "help_desc":"Learn about the TryHackMe room review process",
+            "url":"https://help.tryhackme.com/room-creation/publishing-your-room",
+            "title":"Learn about the TryHackMe room review process!"
+        },
+        "api":{
+            "help_desc":"Read about the TryHackMe API",
+            "url":"https://thm-community.github.io/api-docs/",
+            "title":"Read about the TryHackMe API!"
+        },
+        "koth":{
+            "help_desc":"How to play TryHackMe's King of the Hill (KoTH)",
+            "url":"https://help.tryhackme.com/using-tryhackme/king-of-the-hill",
+            "title":"How to play TryHackMe's King of the Hill (KoTH)"
+        }
+    },
     "socials":{
         "help_desc":"Get links to all our socials.",
         "github":{


### PR DESCRIPTION
… rule 13 (again)

1) Added a !docs command that will provide a a topic based upon an argument given. This will resolve #106 now that the new help site is live.

The topics are stored within `strings.json` and are hardcoded until I can find the time to play around with the HelpJuice API. I've only written the embeds for the common questions

2) Updated rule 13 to the latest wording and approval as of 31/07/2020 by darkstar and Muirl

3) Updated README.md to reflect the new `!docs` command and usage