### PR TITLE
Command Manager refactor and restructure

### DIFF
--- a/cogs/staff_vote.py
+++ b/cogs/staff_vote.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 from discord.utils import get
 
 import libs.config as config
-from libs.command_manager import roles, channels, command
+from libs.command_manager import check
 
 ####################
 # Config variables #
@@ -29,10 +29,11 @@ class StaffVote(commands.Cog, name="Staff Vote"):
         self.bot = bot
 
     @commands.command(name="clearcm", description=s_staff_vote["help_desc"], hidden=True)
+    @check(roles=["admin",
+                  "mod"],
+           channels="staff_voting_cm",
+           dm_flag=False)
     async def clear_cm(self, ctx):
-        if not await command(ctx, roles=[roles.ADMIN, roles.MODLEAD], channels=[channels.STAFF_VOTING_CM]):
-            return
-
         await ctx.channel.purge(limit=100)
         await ctx.send(s_staff_vote["cleared"])
 

--- a/libs/command_manager.py
+++ b/libs/command_manager.py
@@ -90,12 +90,8 @@ def check(roles="",
 
             # 2. Checking for if the message is in the list of channels provided. dm_flag = False for no DM
             if channels:
-                # Converts channels to a string list if not already a list.
-                if type(channels) is str:
-                    channels = [channels]
-                    
+                dm_allowed = dm_flag is not False
                 try:
-                    dm_allowed = dm_flag is not False
                     check_channel(ctx, channels, dm_allowed)
                 # Errors out if channel is not in the channels whitelist
                 except commands.CommandInvokeError as e:
@@ -105,9 +101,6 @@ def check(roles="",
 
             # 3. Checking if the message author has a role in the list of whitelisted roles.
             if roles:
-                # Converts roles to a string list if not already a list.
-                if type(roles) is str:
-                    roles = [roles]
                 try:
                     check_roles(ctx, roles)
                 # Error out if the user does not have any role in the whitelisted roles.
@@ -211,6 +204,8 @@ def check_context(ctx, dm_flag):
 
 def check_channel(ctx, channels, dm_allowed):
     """Checks the current channel is valid for the command with arg channels"""
+    if type(channels) is str:
+        channels = [channels]
     # Converts arg channels into corresponding channel IDs, and check if DM is ok
     valid_channels = [CHANNEL_IDS[channel] for channel in channels]
     dm_appropriate = type(ctx.channel) is DMChannel and dm_allowed
@@ -224,6 +219,8 @@ def check_channel(ctx, channels, dm_allowed):
 
 def check_roles(ctx, roles):
     """Checks that the user has all the required roles."""
+    if type(roles) is str:
+        roles = [roles]
     user = ctx.author
     # Get the list of IDs from user.roles, and list of IDs from arg roles
     user_roles = [role.id for role in user.roles]

--- a/libs/command_manager.py
+++ b/libs/command_manager.py
@@ -60,13 +60,7 @@ def check(roles="",
         CommandInvokeError: Command is not invoked in the whitelist of arg channels.
         MissingAnyRole: Context.author does not have a role in the whitelist of arg roles.
     """
-
-    # Turn a single string arg into a string array.
-    if roles and type(roles) is str:
-        roles = [roles]
-    if channels and type(channels) is str:
-        channels = [channels]
-
+    
     def perm_check(cmd):
         """Wrapper method to allow our own method to be executed before the original method"""
         @functools.wraps(cmd)
@@ -96,7 +90,10 @@ def check(roles="",
 
             # 2. Checking for if the message is in the list of channels provided. dm_flag = False for no DM
             if channels:
-                print(channels)
+                # Converts channels to a string list if not already a list.
+                if type(channels) is str:
+                    channels = [channels]
+                    
                 try:
                     dm_allowed = dm_flag is not False
                     check_channel(ctx, channels, dm_allowed)
@@ -108,6 +105,9 @@ def check(roles="",
 
             # 3. Checking if the message author has a role in the list of whitelisted roles.
             if roles:
+                # Converts roles to a string list if not already a list.
+                if type(roles) is str:
+                    roles = [roles]
                 try:
                     check_roles(ctx, roles)
                 # Error out if the user does not have any role in the whitelisted roles.

--- a/libs/command_manager.py
+++ b/libs/command_manager.py
@@ -1,144 +1,200 @@
+"""Command Manager
+Manages checking conditions for commands that need certain roles to be executed.
+
+Use decorator function @check() to do proper permissions and input sanitation for your command.
+i.e.
+
+@command_manager.check(roles=["admin",
+                              "mod",]
+                       channels=["staff_channel"])
+async fun_command(self, ctx):
+    ...
+
+There is also .sanitize_check(ctx, msg) for input sanitation. Will return false if msg contains
+a forbidden character.
+
+Names of roles and channels are derived from libs.config.get_config() (which comes from config/config.json)
+"""
+
 import libs.config as config
 from discord.channel import DMChannel
-import libs.utils as utils
-from enum import Enum
-
-class Context(Enum):
-    PUBLIC = 1
-    DM = 2
-    BOTH = 3
-
-class _Roles():
-    def __load_ranks(self):
-        RANKS = []
-
-        for rank in self._roles_id:
-            RANKS.append(rank)
-
-        return RANKS
-
-    def __init__(self):
-        self._roles_id = config.get_config("roles")
-
-        self.ADMIN = self._roles_id["admin"]
-        self.MODLEAD = self._roles_id["modlead"]
-        self.MOD = self._roles_id["mod"]
-
-        self.DEVLEAD = self._roles_id["devLead"]
-        self.DEV = self._roles_id["dev"]
-
-        self.VERIFIED = self._roles_id["verified"]
-        self.SUB = self._roles_id["sub"]
-        self.CONTRIB = self._roles_id["contrib"]
-
-        self.ANNOUNCEMENT = self._roles_id["announcementrole"]
-
-        self.RANKS = self.__load_ranks()
-
-class _Channels():
-    def __init__(self):
-        self._roles_id = config.get_config("channels")
-
-        self.WELCOME = self._roles_id["welcome"]
-        self.ANNOUNCEMENTS = self._roles_id["announcements"]
-        self.STATS_THM_USERS = self._roles_id["stats_thm_users"]
-        self.STATS_DISCORD_USERS = self._roles_id["stats_discord_users"]
-        self.STATS_ROOMS = self._roles_id["stats_rooms"]
-        self.STAFF_VOTING_CM = self._roles_id["staff_voting_cm"]
+from discord.ext import commands as error
+import functools
+import asyncio
 
 
-roles = _Roles()
-channels = _Channels()
+# GLOBAL VARIABLES
+ERROR_STRING = config.get_string("commands")
+ROLE_IDS = config.get_config("roles")
+CHANNEL_IDS = config.get_config("channels")
+DEFAULT_BANNED = ["/", ";", "-", ">", "<", ":", "`", "\"", "|"]
 
-s_cmd = config.get_string("commands")
+
+def check(roles=None,
+          channels=None,
+          dm_flag=None):
+    """Decorator for sanitizing arguments and checking permissions."""
+    # Call this decorator function before a command in order to check the specific perms passed into it.
+    # 'msg' is an array (of string, or nestable string array/tuples) of the arguments of the command.
+    # 'roles' is an array (of str) of required role names user must have to execute the command.
+    # 'channels' is an array (of str) of valid channel names that command can be executed in
+    # 'dm_flag' is a bool for three allowed context types
+    #   1.dm_flag is None  - Command can be executed in DMs and any channel
+    #   2.dm_flag is True  - Command can only be executed in DMs
+    #   3.dm_flag is False - Command can only be executed in a discord channel (no DM)
+
+    # Turn arg roles into a list if it is a string for one-role commands.
+    if type(roles) is str:
+        roles = [roles]
+    # Same as above but for channels.
+    if type(channels) is str:
+        channels = [channels]
+
+    # Decorator magic. wrapper() is where the perm checking happens
+    def perm_check(cmd):
+        # Checking for the context.
+        @functools.wraps(cmd)
+        async def wrapper(*args, **kwargs):
+            """Checks permissions of the message before executing command"""
+            # wrapper args is the original args passed to the command being checked
+            # second element of args will always be the discord message (Context object)
+            ctx = args[1]
+
+            # 1. Checking if dm_flag is set and if message is in DMs
+            if dm_flag is not None:
+                try:
+                    check_context(ctx, dm_flag)
+                # Error if message does not fit in DM or public channels.
+                # TODO: log exceptions to debug
+                except error.PrivateMessageOnly as e:
+                    await error_response(ctx, "context_dm_only",
+                                         delete_ctx=True)
+                    return False
+                except error.NoPrivateMessage as e:
+                    await error_response(ctx, "context_public_only",
+                                         delete_msg=False)
+                    return False
+
+            # 2. Checking for if message is in the list of channels provided. dm_flag = False for no DM
+            if channels:
+                try:
+                    dm_allowed = dm_flag is not False
+                    check_channel(ctx, channels, dm_allowed)
+                # Error if channel is not in the listed channels
+                except error.CommandInvokeError as e:
+                    # TODO: log exception to debug
+                    await error_response(ctx, "channel_not_allowed")
+                    return False
+
+            # 3. Checking if the user has permission.
+            if roles:
+                try:
+                    check_roles(ctx, roles)
+                # Error if user does not have any role in list of roles
+                except error.MissingAnyRole as e:
+                    # TODO: log exception to debug
+                    await error_response(ctx, "no_perm")
+                    return False
+
+            # 4. If all checks succeeded, then execute original command.
+            return await cmd(*args, **kwargs)
+
+        return wrapper
+
+    return perm_check
 
 
-def __has_role__(member, id):
-    """Check if the member has the roles."""
+async def is_sanitized(ctx, msg, err_msg="not_sanitized", banned_chars=None):
+    """Checks user input for any forbidden characters.
+    Returns True if sanitary, otherwise throws the discord.ext.commands.BadArgument exception.
+    """
+    # Default banned characters are "/", ";", "-", ">", "<", ":", "`", "\"", "|"
+    # err_msg flag will cause bot to respond with generic error message to ctx.channel if True
 
-    for role in member.roles:
-        if id == role.id:
-            return True
-    return False
+    # Use banned_chars if assigned, otherwise just use the default ban list. (RECOMMENDED)
+    if banned_chars:
+        banned = banned_chars
+    else:
+        banned = DEFAULT_BANNED
 
-def __check_context__(ctx, context):
-    """Checks that the current context fits the desired one."""
-
-    if context == Context.DM and (not isinstance(ctx.channel, DMChannel)):
-        raise Exception(s_cmd["context_dm_only"])
-    elif context == Context.PUBLIC and isinstance(ctx.channel, DMChannel):
-        raise Exception(s_cmd["context_public_only"])
-
-def __check_channel__(ctx, channels):
-    """Checks that the command is executed in one of the allowed channel."""
-
-    is_channel_allowed = False
-
-    for c in channels:
-        if c == ctx.channel.id:
-            __check_channel__ = True
-
-    if not __check_channel__:
-        raise Exception(s_cmd["channel_not_allowed"])
-
-def __check_sanitized__(args):
-    """Checks that every arg in args is sanitized correctly."""
-
-    for arg in args:
-        print("Doing: "+str(arg))
-        if isinstance(arg, tuple) or isinstance(arg, list):
-            __check_sanitized__(arg)
+    for text in msg:
+        # Check to see if arg is a list to also recursively sanitize anything in it
+        if type(text) is tuple or \
+           type(text) is list:
+            await is_sanitized(ctx, text)
         else:
-            if not utils.sanitize_check(arg):
-                raise Exception(s_cmd["not_sanitized"])
+            # Otherwise, check text for sanitation.
+            has_banned_chars = [char for char in text if char in banned]
 
-def __check_roles__(ctx, roles):
+            if has_banned_chars:
+                if err_msg:
+                    await error_response(ctx, err_msg)
+                # TODO: log exception to debug/tracking channel
+                raise error.BadArgument(message=msg)
+    # If all text is sanitary, then return bool True
+    return True
+
+
+async def error_response(ctx, err_msg,
+                         delete_msg=True,
+                         delete_ctx=False):
+    """Sends a bot err_msg to the channel in context, then deletes the error message after 5 seconds.
+    delete flags will determine what gets deleted after 5 seconds.
+    """
+    # Tries to retrieve ERROR_STRING[err_msg], but if not found, then defaults to err_msg
+    error_output = ERROR_STRING.get(err_msg, err_msg)
+
+    bot_message = await ctx.send(error_output)
+
+    if delete_msg or delete_ctx:
+        await asyncio.sleep(5)
+        if delete_msg:
+            await bot_message.delete()
+        if delete_ctx and type(ctx.channel) is not DMChannel:
+            await ctx.message.delete()
+
+
+def check_context(ctx, dm_flag):
+    """Checks if the context is correct (DMs or public channel)"""
+    dm_message = type(ctx.channel) is DMChannel
+
+    # If message is not a DM and the command is DM only (dm_flag True)
+    if not dm_message and dm_flag:
+        raise error.PrivateMessageOnly
+    # If message is a DM but the command is not allowed in DMs (dm_flag False)
+    elif dm_message and not dm_flag:
+        raise error.NoPrivateMessage
+
+    return dm_message
+
+
+def check_channel(ctx, channels, dm_allowed):
+    """Checks the current channel is valid for the command with arg channels"""
+
+    # Converts arg channels into corresponding channel IDs
+    valid_channels = [CHANNEL_IDS[channel] for channel in channels]
+
+    dm_appropriate = type(ctx.channel) is DMChannel and dm_allowed
+
+    # Check if channel is in the list of channels
+    if ctx.channel.id not in valid_channels and not dm_appropriate:
+        raise error.CommandInvokeError(ctx)
+
+    return True
+
+
+def check_roles(ctx, roles):
     """Checks that the user has all the required roles."""
-
     user = ctx.author
-    has_perm = False
+    # Get the list of IDs from user.roles
+    user_roles = [role.id for role in user.roles]
 
-    # We want to know if the user has specific roles.
-    for role in roles:
-        if __has_role__(user, role):
-            has_perm = True
+    # Get the list of required role IDs from roles arg
+    req_roles = [ROLE_IDS[req_role] for req_role in roles]
 
-    if not has_perm:
-        raise Exception(s_cmd["no_perm"])
-
-
-async def command(ctx, args=None, roles=None, channels=None, context=Context.BOTH):
-    """Roles is an array (of roles) of required roles to execute the command. Args is an array (of string, or tuple of str, or array of str) of the arguments of the command."""
-
-    # Checking for the context.
-    try:
-        __check_context__(ctx, context)
-    except Exception as e:
-        await ctx.send(e)
-        return False
-
-    # Checking for the channel in case of a public context.
-    if channels != None and context == Context.PUBLIC:
-        try:
-            __check_channel__(__check_channel__(ctx, channels))
-        except Exception as e:
-            await ctx.send(e)
-            return False
-
-    # Checking if all the args are sanitized.
-    if args != None:
-        try:
-            __check_sanitized__(args)
-        except Exception as e:
-            await ctx.send(e)
-            return False
-
-    # Checking if the user has permission.
-    if roles != None:
-        try:
-            __check_roles__(ctx, roles)
-        except Exception as e:
-            await ctx.send(e)
-            return False
+    # Magic python sentence that checks if there's any roles in user_roles that
+    # is also in the list of req_roles.
+    if not [role for role in user_roles if role in req_roles]:
+        raise error.MissingAnyRole(roles)
 
     return True


### PR DESCRIPTION
Refactored entire file for readability and optimization.
First step to resolving issue https://github.com/DarkStar7471/THM-Bot/issues/125

Major changes:
- check() is now a decorator function, which you can prepend a @command_manager.check() before a command to do all the permission checking before execution.
      - Automatically errors out and sends an error message if matching roles, channel, or DM context is not found. Command is not executed if failed.
      - Context check for DMs is no longer an enum, but is a bool to represent the inclusive DM-Only or No DMs at all states (None to allow both DMs and public channel usage)
      - Removed input sanitation from check() and moved into a standalone public method
- Input sanitation has been moved out of check() due to the timing difference, but is now a public function that can be called with is_sanitized(ctx, input).
      - No longer depends on lib/utils.py
- Error responses have been methodized into command_manager.error_response(ctx, error_message)
      - Allows people to send error messages of their own in a standardized method.
      - Automatically sources error messages from keys in config/config.json["commands"]
      - If a custom one-off error message is desired, then set the parameter to a desired error message string.