### PR TITLE
Implement countries with leaderboard commands

### DIFF
--- a/cogs/leaderboard.py
+++ b/cogs/leaderboard.py
@@ -178,40 +178,26 @@ class Leaderboard(commands.Cog, name="Leaderboard Commands"):
         await asyncio.sleep(config.get_config("sleep_time")["monthly_leaderboard"])
 
     @commands.command(description=s_leader["help_desc"], usage="[page] / [country [page]]")
-    async def leaderboard(self, ctx, *args):
-        page = 1
-        country = None
-
-        if len(args) > 0:
-            try:
-                page = int(args[0])
-            except:
-                country = args[0]
-        if len(args) > 1:
-            try:
-                page = int(args[1])
-            except:
-                pass
+    async def leaderboard(self, ctx, first_arg: typing.Optional[typing.Union[int, str]] = 1, second_arg: typing.Optional[int] = None):
+        if type(first_arg) is int:
+            page = first_arg
+        else:
+            country = first_arg
+            if second_arg is not None:
+                page = second_arg
 
         # The bot will appear as typing while executing the command.
         async with ctx.channel.typing():
             await self.generate_leaderboard(ctx.channel, page, monthly=False, country=country)
 
     @commands.command(description=s_monthly["help_desc"], usage="[page] / [country [page]]")
-    async def monthly(self, ctx, *args):
-        page = 1
-        country = None
-
-        if len(args) > 0:
-            try:
-                page = int(args[0])
-            except:
-                country = args[0]
-        if len(args) > 1:
-            try:
-                page = int(args[1])
-            except:
-                pass
+    async def monthly(self, ctx, first_arg: typing.Optional[typing.Union[int, str]] = 1, second_arg: typing.Optional[int] = None):
+        if type(first_arg) is int:
+            page = first_arg
+        else:
+            country = first_arg
+            if second_arg is not None:
+                page = second_arg
 
         # The bot will appear as typing while executing the command.
         async with ctx.channel.typing():

--- a/config/strings.json
+++ b/config/strings.json
@@ -108,7 +108,8 @@
             "help_desc":"Prints the leaderboard.",
             "generating":"Generating global leaderboard...",
             "footer":"Made with love by the TryHackMe Discord Bot",
-            "invalid_page": "This page doesn't exist. Available pages: {}"
+            "invalid_page": "This page doesn't exist. Available pages: {}",
+            "invalid_country": "This country doesn't return any results."
         },
         "monthly":{
             "help_desc":"Prints this month's leaderboard.",

--- a/libs/thm_api.py
+++ b/libs/thm_api.py
@@ -53,9 +53,14 @@ def get_sub_status(username):
     return check
 
 
-def get_leaderboard_data(monthly: bool = False):
+def get_leaderboard_data(**kwargs):
     """Fetches leaderboard data (all-time/monthly)"""
-    query = '?type=monthly' if monthly else ''
+    if len(kwargs) > 0:
+        query = "?"
+        for key, val in kwargs.items():
+            if val is None:
+                continue
+            query += f'{key}={str(val).lower()}&'
 
     response = requests.get(c_api_leaderboard + query)
     data = response.text


### PR DESCRIPTION
Outline of the changes:
- Changed the way query parameters are handled in `get_leaderboard_data@thm_api`
- Added support for specifying a country when requesting a monthly/all-time leaderboard